### PR TITLE
Keep negligible CVE count column

### DIFF
--- a/filter_data.py
+++ b/filter_data.py
@@ -63,7 +63,7 @@ def filter_df(dataframe, starting_day=None, ending_day=None):
 
     # drop "success" column since that is only interesting for
     # internal chainguard quality control purposes
-    filtered_df = filtered_df.drop(columns=["success", "negligible_cve_cnt"])
+    filtered_df = filtered_df.drop(columns=["success"])
 
     # reset index (done to enable reproducibility during testing)
     filtered_df = filtered_df.reset_index(drop=True)

--- a/filter_data.py
+++ b/filter_data.py
@@ -63,6 +63,8 @@ def filter_df(dataframe, starting_day=None, ending_day=None):
 
     # drop "success" column since that is only interesting for
     # internal chainguard quality control purposes
+    # note: the negligible CVE count column should not be dropped
+    # when using grype
     filtered_df = filtered_df.drop(columns=["success"])
 
     # reset index (done to enable reproducibility during testing)


### PR DESCRIPTION
The negligible CVE count column is associated with grype. Because `data.csv` now uses grype, keep this column in the dataset.