### PR TITLE
Use octo-sts for image-comparison pushes

### DIFF
--- a/.github/workflows/gen-html.yml
+++ b/.github/workflows/gen-html.yml
@@ -22,6 +22,12 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: '3.12'
+      - name: Set up Octo-STS
+        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: chainguard-dev/image-comparison
+          identity: image-comparison
       - name: execute shell script
         id: run
         run: |
@@ -30,8 +36,6 @@ jobs:
         uses: chainguard-dev/actions/setup-gitsign@main
       - name: commit files
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
           git add *.html
           git commit -m "update html"
           git push origin main


### PR DESCRIPTION
This PR updates the `gen-html.yml` Workflow to use octo-sts rather than the GitHub Actions user.

We already have a trust policy for the Workflow in `.chainguard/source.yaml`:
```yaml
- issuer: https://token.actions.githubusercontent.com
  subject: https://github.com/chainguard-dev/image-comparison/.github/workflows/gen-html.yml@refs/heads/main 
```