### PR TITLE
fix(ci): authenticate the gen-html push with octo-sts and harden the workflow

### DIFF
--- a/.github/workflows/gen-html.yml
+++ b/.github/workflows/gen-html.yml
@@ -21,20 +21,24 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: checkout repo content
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
-      - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
-      - uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
-      - name: setup python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
-        with:
-          python-version: '3.12'
       - name: Set up Octo-STS
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
         id: octo-sts
         with:
           scope: chainguard-dev/image-comparison
           identity: gen-html
+      - name: checkout repo content
+        # zizmor: ignore[artipacked] - the scoped octo-sts token below is intentionally
+        # persisted for the `git push origin main` in the "commit files" step
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+      - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
+      - uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
+      - name: setup python
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+        with:
+          python-version: '3.12'
       - name: execute shell script
         id: run
         run: |

--- a/.github/workflows/gen-html.yml
+++ b/.github/workflows/gen-html.yml
@@ -30,7 +30,7 @@ jobs:
       - name: checkout repo content
         # zizmor: ignore[artipacked] - the scoped octo-sts token below is intentionally
         # persisted for the `git push origin main` in the "commit files" step
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           token: ${{ steps.octo-sts.outputs.token }}
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3

--- a/.github/workflows/gen-html.yml
+++ b/.github/workflows/gen-html.yml
@@ -47,7 +47,7 @@ jobs:
         uses: chainguard-dev/actions/setup-gitsign@ec48ea414c0cb207549029d8fe35f8f01e563219 # v1.0.8
       - name: commit files
         run: |
-          git add *.html
+          git add -- *.html
           git commit -m "update html"
           git push origin main
       - if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
**Ticket**: PSEC-923
**Date**: 2026-06-30
**Patches**: 4

---

## Summary

This patch series addresses GitHub Actions security findings in
`chainguard-dev/image-comparison` as part of the PSEC-923 systematic hardening
campaign across Chainguard public repositories. The scheduled `gen-html`
workflow regenerates HTML and pushes it back to `main`; the changes scope the
credential that authenticates that push, correct a pin annotation, and harden
the commit step.

### Patch 0001 — fix(ci): authenticate the gen-html push with the octo-sts token

The "commit files" step runs a bare `git push origin main` that, until now,
authenticated with the default `GITHUB_TOKEN` persisted by `actions/checkout`
(zizmor `artipacked`). The workflow already mints a short-lived, OIDC-federated
octo-sts token (`Set up Octo-STS`), so this moves that step ahead of the
checkout and passes its token to `actions/checkout` via `token:`. The persisted
credential is now the `contents: write`-scoped octo-sts token rather than the
broad default token, and the push continues to work unchanged.

The persistence is intentional (the later step needs the credential for
`git push`), so the checkout carries a documented `# zizmor: ignore[artipacked]`
annotation explaining why.

### Patch 0002 — fix(ci): correct checkout version comment to match pinned SHA

The `actions/checkout` pin carried a `# v4.1.2` comment, but the pinned SHA
`b4ffde65f46336ab88eb53be808477a3936bae11` is `v4.1.1`. Corrects the comment to
match the SHA (zizmor `ref-version-mismatch`); no SHA change.

### Patch 0003 — fix(ci): guard git add glob with end-of-options marker

`git add *.html` lets a filename that begins with `-` be interpreted as an
option (shellcheck `SC2035`). Inserts the `--` end-of-options marker
(`git add -- *.html`) so all expanded arguments are treated as paths.

### Patch 0004 — fix(ci): suppress cosmetic zizmor rules and trigger on config changes

- Adds `.github/zizmor.yml` disabling `anonymous-definition` and
  `concurrency-limits` (pedantic-only rules with no security impact, suppressed
  consistently across the campaign).
- Extends the `paths:` triggers in `.github/workflows/zizmor.yaml` to include
  `.github/zizmor.yml`, so changes to the config also run the check.

---

## Testing

- Apply with `git am --3way --keep-cr 00*-*.patch`
- `zizmor --persona pedantic .github/` reports no findings
- `actionlint .github/workflows/gen-html.yml` is clean

---

Refs: PSEC-923